### PR TITLE
Add ADC example for AI Thinker Audio Kit

### DIFF
--- a/examples/yummyAudioKit/yummyAudioKit.ino
+++ b/examples/yummyAudioKit/yummyAudioKit.ino
@@ -30,7 +30,7 @@
 #define I2S_BCK_PIN                 27
 #define I2S_LRCLK_PIN               26
 #define I2S_DOUT_PIN                25
-#define I2S_DIN_PIN             13 // ?
+#define I2S_DIN_PIN             	35
 
 #define GPIO_PA_EN                  GPIO_NUM_21
 #define GPIO_SEL_PA_EN              GPIO_SEL_21

--- a/examples/yummyAudioKitADC/yummyAudioKitADC.ino
+++ b/examples/yummyAudioKitADC/yummyAudioKitADC.ino
@@ -1,0 +1,206 @@
+/*      
+  This example is ripped off the AC101 Arduino library for the AIThinker ESP32-A1S: 
+  https://github.com/Yveaux/AC101
+      
+  AC101 Codec driver library example.
+  Uses the ESP32-A1S module with integrated AC101 codec, mounted on the ESP32 Audio Kit board:
+  https://wiki.ai-thinker.com/esp32-audio-kit
+  
+  Copyright (C) 2019, Ivo Pullens, Emmission
+  
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <YummyDSP.h>
+#include <AudioDriver.h>
+#include <Codecs/AC101/AC101.h>
+
+#define I2S_BCK_PIN                 27
+#define I2S_LRCLK_PIN               26
+#define I2S_DOUT_PIN                25
+#define I2S_DIN_PIN                 35
+
+#define GPIO_PA_EN                  GPIO_NUM_21
+#define GPIO_SEL_PA_EN              GPIO_SEL_21
+
+#define PIN_VOL_UP                  (18)      // KEY 5
+#define PIN_VOL_DOWN                (5)       // KEY 6
+#define PIN_INPUT_SELECT            (23)      // KEY 4
+
+static AC101 i2sCodec;
+YummyDSP dsp;
+FilterNode lp;
+FilterNode hp;
+MixerNode gain;
+WaveShaperNode sat;
+
+// I2S
+const int fs = 96000;
+const int channelCount = 2;
+
+static uint8_t volume = 12;
+const uint8_t volume_step = 2;
+int input_select = 1;
+
+int debounce = 0;
+
+void audioTask(void *);
+
+
+void setup()
+{
+  Serial.begin(115200);
+
+  Serial.printf("Connect to AC101 codec... ");
+
+  // setup audio codec
+  i2sCodec.setup(fs, channelCount, I2S_BCK_PIN, I2S_LRCLK_PIN, I2S_DOUT_PIN, I2S_DIN_PIN, GPIO_PA_EN);
+
+  i2sCodec.SetVolumeSpeaker(volume);
+  i2sCodec.SetVolumeHeadphone(volume);
+  i2sCodec.SetMode(i2sCodec.MODE_LINE);
+  //i2sCodec.DumpRegisters();
+
+  // Enable amplifier
+  pinMode(GPIO_PA_EN, OUTPUT);
+  digitalWrite(GPIO_PA_EN, HIGH);
+
+  // Configure keys on ESP32 Audio Kit board
+  pinMode(PIN_INPUT_SELECT, INPUT_PULLUP);
+  pinMode(PIN_VOL_UP, INPUT_PULLUP);
+  pinMode(PIN_VOL_DOWN, INPUT_PULLUP);
+
+  Serial.printf("Use KEY5/KEY6 for volume Up/Down\n");
+  Serial.printf("Use KEY4 for Input Select\n");
+  Serial.printf("Line In selected by default\n");
+
+  // setup audio lib
+  dsp.begin(fs);
+
+  // setup some filter nodes
+  lp.begin(fs, channelCount);
+  lp.setupFilter(FilterNode::LPF, 5000, 1.7);
+
+  hp.begin(fs, channelCount);
+  hp.setupFilter(FilterNode::HPF, 100, 1.0);
+  
+  gain.begin(fs, channelCount);
+  gain.setVolumedB(0,false);
+  
+  sat.begin(fs, channelCount);
+  sat.setDrive(0.5f);
+
+  // add nodes to audio processing tree
+  // Synth => hp => lp => I2S out
+  dsp.addNode(&hp);
+  dsp.addNode(&lp);
+  dsp.addNode(&gain);
+  dsp.addNode(&sat);
+
+  // run audio in dedicated task on cpu core 1
+  xTaskCreatePinnedToCore(audioTask, "audioTask", 10000, NULL, 10, NULL, 1);
+  // run control task on another cpu  core with lower priority
+  Serial.print("\nSetup done ");
+
+}
+
+bool pressed( const int pin )
+{
+  if (millis() > (debounce + 500))
+  {
+    if (digitalRead(pin) == LOW)
+    {
+      debounce = millis();
+      return true;
+    }
+  }
+  return false;
+}
+
+
+void audioTask(void *) {
+
+  Serial.print("\nAudio task");
+
+  float sample = 0;
+
+  while (true) {
+	  
+	i2sCodec.readBlock();
+
+    for (int i = 0; i < AudioDriver::BufferSize; i++) {
+
+      for (int ch = 0; ch < channelCount; ch++) {
+		  
+		sample = i2sCodec.readSample(i, ch);
+
+        sample = dsp.process(sample, ch);
+
+        i2sCodec.writeSample(sample, i, ch);
+      }
+    }
+
+    i2sCodec.writeBlock();
+  }
+  vTaskDelete(NULL);
+}
+
+
+void loop()
+{
+  bool updateVolume = false;
+
+  delay(2);
+
+  if (pressed(PIN_VOL_UP))
+  {
+    if (volume <= (63 - volume_step))
+    {
+      // Increase volume
+      volume += volume_step;
+      updateVolume = true;
+    }
+  }
+  if (pressed(PIN_VOL_DOWN))
+  {
+    if (volume >= volume_step)
+    {
+      // Decrease volume
+      volume -= volume_step;
+      updateVolume = true;
+    }
+  }
+  if (updateVolume)
+  {
+    // Volume change requested
+    Serial.printf("Volume %d\n", volume);
+    i2sCodec.SetVolumeSpeaker(volume);
+    i2sCodec.SetVolumeHeadphone(volume);
+  }
+  if (pressed(PIN_INPUT_SELECT))
+	if (input_select == 0)
+	{
+		Serial.printf("Line In Selected\n");
+		i2sCodec.SetMode(i2sCodec.MODE_LINE);
+		input_select = 1;
+	}
+	else if (input_select == 1)
+	{
+		Serial.printf("Mic Selected\n");
+		i2sCodec.SetMode(i2sCodec.MODE_MIC);
+		input_select = 0;
+	}
+	
+}

--- a/src/Codecs/AC101/AC101.cpp
+++ b/src/Codecs/AC101/AC101.cpp
@@ -245,7 +245,7 @@ bool AC101::begin(int fs)
 	// Path Configuration
 	ok &= WriteReg(DAC_MXR_SRC, 0xcc00);
 	ok &= WriteReg(DAC_DIG_CTRL, 0x8000);
-	ok &= WriteReg(OMIXER_SR, 0x0102);
+	ok &= WriteReg(OMIXER_SR, 0x0081);
 	ok &= WriteReg(OMIXER_DACA_CTRL, 0xf080);
 
 	ok &= SetMode(MODE_ADC_DAC);

--- a/src/Codecs/AC101/AC101.cpp
+++ b/src/Codecs/AC101/AC101.cpp
@@ -245,10 +245,10 @@ bool AC101::begin(int fs)
 	// Path Configuration
 	ok &= WriteReg(DAC_MXR_SRC, 0xcc00);
 	ok &= WriteReg(DAC_DIG_CTRL, 0x8000);
-	ok &= WriteReg(OMIXER_SR, 0x0081);
+	ok &= WriteReg(OMIXER_SR, 0x0102);
 	ok &= WriteReg(OMIXER_DACA_CTRL, 0xf080);
 
-	ok &= SetMode( MODE_ADC_DAC);
+	ok &= SetMode(MODE_ADC_DAC);
 
 	return ok;
 }
@@ -343,16 +343,22 @@ bool AC101::SetMode(Mode_t mode)
 	{
 		ok &= WriteReg(ADC_SRC, 0x0408);
 		ok &= WriteReg(ADC_DIG_CTRL, 0x8000);
-		ok &= WriteReg(ADC_APC_CTRL, 0x3bc0);
+		ok &= WriteReg(ADC_APC_CTRL, 0xbb00);
+	}
+	if (MODE_MIC == mode)
+	{
+		ok &= WriteReg(ADC_SRC, 0x2020);
+		ok &= WriteReg(ADC_DIG_CTRL, 0x8000);
+		ok &= WriteReg(ADC_APC_CTRL, 0xbbc3);
 	}
 
-	if ((MODE_ADC == mode) or (MODE_ADC_DAC == mode) or (MODE_LINE == mode))
+	if ((MODE_ADC == mode) or (MODE_ADC_DAC == mode))
 	{
 		ok &= WriteReg(MOD_CLK_ENA,  0x800c);
 		ok &= WriteReg(MOD_RST_CTRL, 0x800c);
 	}
 
-	if ((MODE_DAC == mode) or (MODE_ADC_DAC == mode) or (MODE_LINE == mode))
+	if ((MODE_DAC == mode) or (MODE_ADC_DAC == mode))
 	{
 		// Enable Headphone output
 		ok &= WriteReg(OMIXER_DACA_CTRL, 0xff80);

--- a/src/Codecs/AC101/AC101.h
+++ b/src/Codecs/AC101/AC101.h
@@ -93,7 +93,8 @@ public:
 		MODE_ADC,
 		MODE_DAC,
 		MODE_ADC_DAC,
-		MODE_LINE
+		MODE_LINE,
+		MODE_MIC
 	} Mode_t;
 
 	// Constructor.

--- a/src/Nodes/StatisticsNode.cpp
+++ b/src/Nodes/StatisticsNode.cpp
@@ -1,0 +1,55 @@
+/*
+ * 	StatisticsNode
+ *
+ *  Author: Ben Marshall
+ * 
+ */
+
+#include <Nodes/StatisticsNode.h>
+
+StatisticsNode::StatisticsNode() {
+	; // be sure to call begin(fs)
+}
+
+StatisticsNode::StatisticsNode(int fs, int channelCount) {
+	this->begin(fs, channelCount);
+}
+
+StatisticsNode::~StatisticsNode() {
+	;
+}
+
+void StatisticsNode::begin(int sampleRate, int channelCount) {
+	this->channelCount = constrain(channelCount, 1, 2);
+	this->reset();
+}
+
+
+float StatisticsNode::processSample(float sample, int channel) {
+	channel = constrain(channel, 0, this->channelCount-1);
+	if (sample < minValue[channel]) {
+		minValue[channel] = sample;
+	}
+	if (sample > maxValue[channel]) {
+		maxValue[channel] = sample;
+	}
+}
+
+
+float StatisticsNode::getMaxValue(int channel) {
+	channel = constrain(channel, 0, this->channelCount-1);
+	return maxValue[channel];
+}
+
+
+
+float StatisticsNode::getMinValue(int channel) {
+	channel = constrain(channel, 0, this->channelCount-1);
+	return minValue[channel];
+}
+
+
+void StatisticsNode::reset() {
+	memset(maxValue, 0, sizeof(maxValue));
+	memset(minValue, 0, sizeof(minValue));
+}

--- a/src/Nodes/StatisticsNode.h
+++ b/src/Nodes/StatisticsNode.h
@@ -1,0 +1,41 @@
+/*
+ * 	StatisticsNode
+ *
+ *  Author: Ben Marshall
+ * 
+ */
+
+#include "Arduino.h"
+#include "Nodes/AudioNode.h"
+
+#ifndef STATISTICS_H
+#define STATISTICS_H
+
+
+class StatisticsNode : public AudioNode {
+
+public:
+
+	StatisticsNode();
+	StatisticsNode(int fs, int channelCount);
+	~StatisticsNode();
+
+	void begin(int fs, int channelCount);
+
+	float processSample(float sample, int channel);
+
+	float getMaxValue(int channel);
+
+	float getMinValue(int channel);
+	
+	void reset();
+
+
+protected:
+	int fs; // sample rate
+	int channelCount; // Channel Count
+	float maxValue[2]; // Maximum detected value
+	float minValue[2]; // Minimum detected value
+};
+
+#endif

--- a/src/YummyDSP.h
+++ b/src/YummyDSP.h
@@ -16,6 +16,7 @@
 #include "Nodes/MixerNode.h"
 #include "Nodes/WaveShaperNode.h"
 #include "Nodes/DelayNode.h"
+#include "Nodes/StatisticsNode.h"
 
 #include "WaveSynth.h"
 #include <list>


### PR DESCRIPTION
This update adds a working example for using the ADC on the AI Thinker Audio Kit board. Both on-board mics and the line in have been tested and are demonstrated here.

This update also applies a small fix to the AC101 codec library to allow the mic and line inputs to be switched live.

It would be great to have these examples added to the main library to help show the capabilities of this cheap dev board.