### PR TITLE
Add AI Thinker ESP32 Audio Kit example

### DIFF
--- a/src/Codecs/AC101/AC101.cpp
+++ b/src/Codecs/AC101/AC101.cpp
@@ -245,7 +245,7 @@ bool AC101::begin(int fs)
 	// Path Configuration
 	ok &= WriteReg(DAC_MXR_SRC, 0xcc00);
 	ok &= WriteReg(DAC_DIG_CTRL, 0x8000);
-	ok &= WriteReg(OMIXER_SR, 0x0102);
+	ok &= WriteReg(OMIXER_SR, 0x0081);
 	ok &= WriteReg(OMIXER_DACA_CTRL, 0xf080);
 
 	ok &= SetMode(MODE_ADC_DAC);

--- a/src/Codecs/AC101/AC101.cpp
+++ b/src/Codecs/AC101/AC101.cpp
@@ -245,10 +245,10 @@ bool AC101::begin(int fs)
 	// Path Configuration
 	ok &= WriteReg(DAC_MXR_SRC, 0xcc00);
 	ok &= WriteReg(DAC_DIG_CTRL, 0x8000);
-	ok &= WriteReg(OMIXER_SR, 0x0081);
+	ok &= WriteReg(OMIXER_SR, 0x0102);
 	ok &= WriteReg(OMIXER_DACA_CTRL, 0xf080);
 
-	ok &= SetMode( MODE_ADC_DAC);
+	ok &= SetMode(MODE_ADC_DAC);
 
 	return ok;
 }
@@ -343,16 +343,22 @@ bool AC101::SetMode(Mode_t mode)
 	{
 		ok &= WriteReg(ADC_SRC, 0x0408);
 		ok &= WriteReg(ADC_DIG_CTRL, 0x8000);
-		ok &= WriteReg(ADC_APC_CTRL, 0x3bc0);
+		ok &= WriteReg(ADC_APC_CTRL, 0xbb00);
+	}
+	if (MODE_MIC == mode)
+	{
+		ok &= WriteReg(ADC_SRC, 0x2020);
+		ok &= WriteReg(ADC_DIG_CTRL, 0x8000);
+		ok &= WriteReg(ADC_APC_CTRL, 0xbbc3);
 	}
 
-	if ((MODE_ADC == mode) or (MODE_ADC_DAC == mode) or (MODE_LINE == mode))
+	if ((MODE_ADC == mode) or (MODE_ADC_DAC == mode))
 	{
 		ok &= WriteReg(MOD_CLK_ENA,  0x800c);
 		ok &= WriteReg(MOD_RST_CTRL, 0x800c);
 	}
 
-	if ((MODE_DAC == mode) or (MODE_ADC_DAC == mode) or (MODE_LINE == mode))
+	if ((MODE_DAC == mode) or (MODE_ADC_DAC == mode))
 	{
 		// Enable Headphone output
 		ok &= WriteReg(OMIXER_DACA_CTRL, 0xff80);

--- a/src/Codecs/AC101/AC101.h
+++ b/src/Codecs/AC101/AC101.h
@@ -93,7 +93,8 @@ public:
 		MODE_ADC,
 		MODE_DAC,
 		MODE_ADC_DAC,
-		MODE_LINE
+		MODE_LINE,
+		MODE_MIC
 	} Mode_t;
 
 	// Constructor.


### PR DESCRIPTION
This update adds a working example for using the ADC on the AI Thinker ESP32 Audio Kit board. Both on-board mics and the line in have been tested and are demonstrated here.

This update also applies a small fix to the AC101 codec library to allow the mic and line inputs to be switched live.

It would be great to have these examples added to the main library to help show the capabilities of this cheap dev board.