### PR TITLE
+reverb; +psram for delay; -deprecated i2s constants;

### DIFF
--- a/examples/yummyBasic/yummyBasic.ino
+++ b/examples/yummyBasic/yummyBasic.ino
@@ -5,7 +5,7 @@
 
 */
 
-#include "Arduino.h"
+
 #include "driver/gpio.h"
 #include <YummyDSP.h>
 #include <AudioDriver.h>
@@ -15,11 +15,12 @@ YummyDSP dsp;
 FilterNode lp;
 FilterNode hp;
 WaveShaperNode sat;
-DelayNode dly;
+DelayNode  dly;
+ReverbNode rvb;
 
 // I2S
 const int fs = 48000;
-const int channelCount = 2;
+const int channelCount = 1;
 
 // Audio Amp Pins
 #define I2S_BCK_PIN 26
@@ -32,22 +33,22 @@ const int channelCount = 2;
 #define POT_PIN 4
 float pot=0.f;
 
-
 void audioTask(void *);
-
 
 void setup() {
 
+  btStop(); // we don't want bluetooth to consume our precious cpu time 
+  
   Serial.begin(115200);
-  Serial.print("\n\nSetup ");
-
+  Serial.print("\n\nSetup \r\n");
+  
+  heap_caps_print_heap_info(MALLOC_CAP_8BIT);
+  
   // setup audio codec
-  i2sCodec.setup(fs, channelCount, I2S_BCK_PIN, I2S_LRCLK_PIN, I2S_DOUT_PIN, I2S_DIN_PIN, CODEC_ENABLE_PIN);
+    i2sCodec.setup(fs, channelCount, I2S_BCK_PIN, I2S_LRCLK_PIN, I2S_DOUT_PIN, I2S_DIN_PIN, CODEC_ENABLE_PIN);
   i2sCodec.mute(false);
-
   // setup audio lib
   dsp.begin(fs);
-
   // setup some filter nodes
   lp.begin(fs, channelCount);
   lp.setupFilter(FilterNode::LPF, 5000, 0.7);
@@ -55,21 +56,29 @@ void setup() {
   hp.begin(fs, channelCount);
   hp.setupFilter(FilterNode::HPF, 30, 1.0);
 
-  dly.begin(fs, channelCount);
-  dly.setDelayMs(150.f);
-
   sat.begin(fs, channelCount);
   sat.setDrive(0.2f);
+  
+  dly.begin(fs, channelCount);
+  dly.setDelayMs( dly.maxDelayMs(),false);
+  
+  rvb.begin(fs, channelCount);
+  rvb.setTime(0.5f);
+  rvb.setMix(1.0f);
 
+  Serial.print("\n\effects created \r\n");
+  
+  heap_caps_print_heap_info(MALLOC_CAP_8BIT);
   // add nodes to audio processing tree
   // I2S in => hp => delay => saturation => lp => I2S out
-  dsp.addNode(&hp);
-  dsp.addNode(&dly);
-  dsp.addNode(&sat);
-  dsp.addNode(&lp);
+    dsp.addNode(&hp);
+    dsp.addNode(&sat);
+    dsp.addNode(&dly);
+    dsp.addNode(&lp);
+    dsp.addNode(&rvb);
 
   // run audio in dedicated task on cpu core 1
-  xTaskCreatePinnedToCore(audioTask, "audioTask", 10000, NULL, 10, NULL, 1);
+  xTaskCreatePinnedToCore(audioTask, "audioTask", 10000, NULL, 10, NULL, 0);
   // run control task on another cpu  core with lower priority
 
   Serial.print("\nSetup done ");
@@ -94,7 +103,7 @@ void audioTask(void *) {
       sample = i2sCodec.readSample(i, ch);
       
       sample = dsp.process(sample, ch);
-
+      
       i2sCodec.writeSample(sample, i, ch);
       }
     }
@@ -110,18 +119,21 @@ void loop()
 {
 
   // sample the potentiometer multiple times, adc is too noisy 
-  int readCnt = 50;
+  int readCnt = 5;
   float p = analogRead(POT_PIN);
   for (int i=0; i<readCnt; i++) {
     p += analogRead(POT_PIN);
   }
   // low pass filtered and scaled between 0-1
-  pot = pot*0.99 + (float)p/4096/(1+readCnt) * 0.01;
+  pot = pot*0.95 + (float)p/4096/(1+readCnt) * 0.05;
 
-  delay(1);
+  delay(20);
 
-  //lp.updateFilter(pot * 10000.f);
+//  lp.updateFilter(pot * 10000.f);
 //  sat.setDrive(pot);
-  dly.setDelayMs(pot * dly.maxDelayMs());
-
+//  dly.setDelayMs(pot * dly.maxDelayMs());
+  rvb.setTime(pot);
+ // Serial.print(pot);
+  taskYIELD();
+  //vTaskDelete(NULL);
 }

--- a/src/AudioDriver.h
+++ b/src/AudioDriver.h
@@ -15,7 +15,7 @@
 #include "driver/i2s.h"
 
 #define BITS_PER_SAMPLE 32 // can be 8, 16, 24 or 32
-#define BUF_SIZE 32 // buffer size in SAMPLES
+#define BUF_SIZE 32 // buffer size in SAMPLES, increase to 64 to avoid drop outs at 192 kHz
 
 enum i2s_alignment {
 	CODEC_I2S_ALIGN = 0,
@@ -26,9 +26,9 @@ class AudioDriver {
 
 public:
 	static const uint32_t BitsPerSample = BITS_PER_SAMPLE;
-	static constexpr float ScaleFloat2Int = ((uint32_t)(1<<(BitsPerSample-1)));
-	static constexpr float ScaleInt2Float = 1.0f/ScaleFloat2Int;
-	static const int BufferSize = BUF_SIZE; // increase to 64 samples to avoid drop outs (at 192 kHz)
+	static constexpr float ScaleFloat2Int = (uint32_t)(1<<(BitsPerSample-1));
+	static constexpr float ScaleInt2Float = 0,992f/ScaleFloat2Int;
+	static const int BufferSize = BUF_SIZE; 
 
 public:
 
@@ -56,7 +56,7 @@ public:
 	}
 
 	inline float int2Float(int32_t iSample) {
-		return ((float)iSample * ScaleInt2Float * 0.992f);
+		return ((float)iSample * ScaleInt2Float);
 	}
 
 	inline float readSample(int n, int channel) {

--- a/src/Codecs/AC101/AC101.cpp
+++ b/src/Codecs/AC101/AC101.cpp
@@ -186,7 +186,8 @@ int AC101::setup(int fs, int channelCount, int bitClkPin, int lrClkPin, int data
 	SetVolumeHeadphone(volume);
 
 	int mclk_fs = 512;
-	i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
+	// i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB); // depricated
+	i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S);
 	int err = setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, comm_fmt, CODEC_I2S_ALIGN, mclk_fs);
 	err += setPins(bitClkPin, lrClkPin, dataOutPin, dataInPin, enablePin);
 	err += start();

--- a/src/Codecs/AK455x/AK455x.cpp
+++ b/src/Codecs/AK455x/AK455x.cpp
@@ -18,7 +18,7 @@ int AK4552::setup(int fs, int channelCount, int bitClkPin, int lrClkPin, int dat
 	this->i2sPort = constrain(i2s_port, I2S_NUM_0, I2S_NUM_MAX);
 
 	int mclk_fs = 384;
-	int err = setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_PCM, CODEC_LJ_RJ_ALIGN, mclk_fs);
+	int err = setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_STAND_PCM_SHORT, CODEC_LJ_RJ_ALIGN, mclk_fs);
 	err += setPins(bitClkPin, lrClkPin, dataOutPin, dataInPin, enablePin);
 	err += start();
 	return err;
@@ -68,16 +68,16 @@ int AK4556::setup(int mode, int fs, int channelCount, int bitClkPin, int lrClkPi
 		case 1:
 		case 2:
 		case 3:
-			err += setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_PCM, CODEC_LJ_RJ_ALIGN, mclk_fs);
+			err += setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_STAND_PCM_SHORT, CODEC_LJ_RJ_ALIGN, mclk_fs);
 		 	break;
 		case 4:
 		case 5:
 		case 6:
 		case 7: 
-			err += setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_I2S_MSB, CODEC_I2S_ALIGN, mclk_fs); 
+			err += setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_STAND_I2S, CODEC_I2S_ALIGN, mclk_fs); 
 			break;
 		default:
-            err += setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_PCM, CODEC_LJ_RJ_ALIGN, mclk_fs);
+            err += setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_32BIT, I2S_COMM_FORMAT_STAND_PCM_SHORT, CODEC_LJ_RJ_ALIGN, mclk_fs);
             break;
 	}
 	

--- a/src/Codecs/ES8388/ES8388.cpp
+++ b/src/Codecs/ES8388/ES8388.cpp
@@ -132,7 +132,8 @@ int ES8388::setup(int fs, int channelCount, int bitClkPin, int lrClkPin, int dat
     Serial.println("Nyambung ke Codec = Sukses/OK");
  	
 	int mclk_fs = 256;//512;
-	i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
+	// i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB); // depricated
+	i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S);
 	int err = setFormat(fs, channelCount, I2S_BITS_PER_SAMPLE_24BIT, comm_fmt, CODEC_I2S_ALIGN, mclk_fs);
 	err += setPins(bitClkPin, lrClkPin, dataOutPin, dataInPin, enablePin);
 	err += start();	

--- a/src/Codecs/ES8388/ES8388.h
+++ b/src/Codecs/ES8388/ES8388.h
@@ -25,7 +25,7 @@
 // #include <inttypes.h>
 #include "Arduino.h"
 #include "AudioDriver.h"
-
+	
 class ES8388: public AudioDriver {
 
 public:

--- a/src/Nodes/AudioNode.h
+++ b/src/Nodes/AudioNode.h
@@ -9,8 +9,7 @@
 #define AUDIONODE
 
 #include <stdio.h>
-#include "dspHelpers.h"
-
+	
 class AudioNode {
 public:
 	virtual ~AudioNode() {};

--- a/src/Nodes/DelayNode.cpp
+++ b/src/Nodes/DelayNode.cpp
@@ -4,9 +4,19 @@
  *  Author: Gary Grutzek
  * 	gary@ib-gru.de
  */
+#define DEBUG_FX
+
+#ifdef DEBUG_FX 
+  #define DEB(...) Serial.print(__VA_ARGS__) 
+  #define DEBF(...) Serial.printf(__VA_ARGS__) 
+  #define DEBUG(...) Serial.println(__VA_ARGS__) 
+#else
+  #define DEB(...)
+  #define DEBF(...)
+  #define DEBUG(...) 
+#endif
 
 #include <Nodes/DelayNode.h>
-
 
 DelayLine::DelayLine() {
 	channelCount = 1;
@@ -15,7 +25,22 @@ DelayLine::DelayLine() {
 
 
 void DelayLine::begin(int channelCount) {
-	memset(buffer, 0, sizeof(buffer));
+#ifdef BOARD_HAS_PSRAM 
+	buffer = (float *)ps_malloc(sizeof(float) * MAX_DELAY_LEN);
+	if( buffer == NULL){
+		DEBUG("No more PSRAM for delay!\n");
+	} else {
+		DEBUG("PSRAM buffer allocated for delay");
+	}
+#else
+	buffer = (float *)malloc(sizeof(float) * MAX_DELAY_LEN);
+	if( buffer == NULL){
+		DEBUG("No more RAM for delay!");
+	} else {
+		DEBUG("RAM buffer allocated for delay");
+	}		
+#endif
+	memset(buffer, 0, sizeof(float) * MAX_DELAY_LEN);
 	this->channelCount = constrain(channelCount, 1, 2);
 	length = MAX_DELAY_LEN / channelCount;
 	writeIndex = 0;
@@ -46,8 +71,6 @@ float DelayLine::pop(int channel) {
 void DelayLine::setSampleDelay(int delay) {
 	sampleDelay = constrain(delay, 0, MAX_DELAY_LEN);
 }
-
-
 
 DelayNode::DelayNode() {
 	; // be sure to call begin(fs)
@@ -114,5 +137,6 @@ void DelayNode::setDelayMs(float ms, bool fade) {
 	interpolator->add(&delayMillis[kCurrent], delayMillis[kTarget]);
 
 	delayLine.setSampleDelay(floor(delayMillis[kCurrent] * fs * 0.001));
+	DEBF("delay %5.3f\r\n", ms);
 }
 

--- a/src/Nodes/DelayNode.h
+++ b/src/Nodes/DelayNode.h
@@ -14,8 +14,11 @@
 #ifndef DELAYNODE_H
 #define DELAYNODE_H
 
-
+#ifdef BOARD_HAS_PSRAM
+#define MAX_DELAY_LEN (48000) 
+#else
 #define MAX_DELAY_LEN (12000) // 520kB RAM is a show stopper
+#endif
 
 class DelayLine {
 
@@ -31,7 +34,7 @@ public:
 
 protected:
 
-	float buffer[MAX_DELAY_LEN + 1];
+	float *buffer ;
 	int length;
 	int channelCount;
 	int sampleDelay;

--- a/src/Nodes/FilterNode.h
+++ b/src/Nodes/FilterNode.h
@@ -13,7 +13,6 @@
 #ifndef FILTER_H
 #define FILTER_H
 
-
 class FilterNode : public AudioNode {
 
 	enum coeffs {
@@ -47,6 +46,7 @@ public:
 
 protected:
 	int fs; // sample rate
+	float div_fs; // fs reciprocal 
 	Interpolator *interpolator;
 
 

--- a/src/Nodes/MixerNode.cpp
+++ b/src/Nodes/MixerNode.cpp
@@ -8,6 +8,8 @@
 
 #include <Nodes/MixerNode.h>
 
+#include "dspHelpers.h"
+
 MixerNode::MixerNode() {
 	; // be sure to call begin(fs)
 }
@@ -46,5 +48,5 @@ void MixerNode::setVolume(float vol, bool fade) {
 
 void MixerNode::setVolumedB(float dB, bool fade) {
 	float x = constrain(dB, -120.f, 0.f);
-	setVolume(pow(10, x / 20.f), fade);
+	setVolume(pow(10, x * 0.05f), fade);
 }

--- a/src/Nodes/MixerNode.h
+++ b/src/Nodes/MixerNode.h
@@ -9,7 +9,7 @@
 #include "Arduino.h"
 #include "Nodes/AudioNode.h"
 #include "Interpolator.h"
-
+	
 #ifndef MIXER_H
 #define MIXER_H
 

--- a/src/Nodes/ReverbNode.h
+++ b/src/Nodes/ReverbNode.h
@@ -1,0 +1,265 @@
+/*
+ *
+ * src: https://github.com/YetAnotherElectronicsChannel/STM32_DSP_Reverb/blob/master/code/Src/main.c
+ *
+ * The explanation of the original module can be found here: https://youtu.be/nRLXNmLmHqM
+ *
+ *
+ *
+ */
+ 
+#include "Arduino.h"
+#include "Nodes/AudioNode.h"
+#include "Nodes/FilterNode.h"
+
+//#define DEBUG_FX
+
+#ifdef DEBUG_FX 
+  #define DEB(...) Serial.print(__VA_ARGS__) 
+  #define DEBF(...) Serial.printf(__VA_ARGS__) 
+  #define DEBUG(...) Serial.println(__VA_ARGS__) 
+#else
+  #define DEB(...)
+  #define DEBF(...)
+  #define DEBUG(...) 
+#endif
+  
+#define STATIC_REV_BUFFER
+
+#ifdef BOARD_HAS_PSRAM 
+#define REV_MULTIPLIER 1.2f
+#else
+#define REV_MULTIPLIER 0.35f
+#endif
+
+#define l_CB0 (int)( 3604 * REV_MULTIPLIER)
+#define l_CB1 (int)( 3112 * REV_MULTIPLIER)
+#define l_CB2 (int)( 4044 * REV_MULTIPLIER)
+#define l_CB3 (int)( 4492 * REV_MULTIPLIER)
+#define l_AP0 (int)( 500 * REV_MULTIPLIER)
+#define l_AP1 (int)( 168 * REV_MULTIPLIER)
+#define l_AP2 (int)( 48 * REV_MULTIPLIER)
+
+
+//rev_time 0.0 <-> 1.0
+//rev_delay 0.0 <-> 1.0
+
+class ReverbNode : public AudioNode {
+	public:
+	ReverbNode() {};
+	ReverbNode(int sampleRate, int channelCount) {};
+	~ReverbNode() {};
+	
+  	inline float processSample( float inSample, int channel  ){
+   		float newsample = (Do_Comb0(inSample) + Do_Comb1(inSample) + Do_Comb2(inSample) + Do_Comb3(inSample)) * 0.125f;
+  		newsample = Do_Allpass0(newsample);
+  		newsample = Do_Allpass1(newsample);
+  		newsample = Do_Allpass2(newsample);
+  
+  		// apply reverb level 
+  		newsample *= rev_level;
+  
+  		inSample += newsample; 
+		return inSample;
+  	};
+  
+  	inline void begin(int sampleRate, int channelCount){ 
+  		setMix( 1.0f );
+  		setTime( 0.75f );
+#ifndef STATIC_REV_BUFFER
+      cfbuf0 = (float *)malloc(sizeof(float) * l_CB0);
+      if( cfbuf0 == NULL){
+        DEBUG("No more RAM for reverb cb0!");
+      } else {
+        DEBUG("Memory allocated for reverb cb0");
+      };
+      cfbuf1 = (float *)malloc(sizeof(float) * l_CB1);
+      if( cfbuf1 == NULL){
+        DEBUG("No more RAM for reverb cb1!");
+      } else {
+        DEBUG("Memory allocated for reverb cb1");
+      };
+      cfbuf2 = (float *)malloc(sizeof(float) * l_CB2);
+      if( cfbuf2 == NULL){
+        DEBUG("No more RAM for reverb cb2!");
+      } else {
+        DEBUG("Memory allocated for reverb cb2");
+      };
+      cfbuf3 = (float *)malloc(sizeof(float) * l_CB3);
+      if( cfbuf3 == NULL){
+        DEBUG("No more RAM for reverb cb3!");
+      } else {
+        DEBUG("Memory allocated for reverb cb3");
+      };      
+      apbuf0 = (float *)malloc(sizeof(float) * l_AP0);
+      if( apbuf0 == NULL){
+        DEBUG("No more RAM for reverb apbuf0!");
+      } else {
+        DEBUG("Memory allocated for reverb apbuf0");
+      };
+      apbuf1 = (float *)malloc(sizeof(float) * l_AP1);
+      if( apbuf1 == NULL){
+        DEBUG("No more RAM for reverb apbuf1!");
+      } else {
+        DEBUG("Memory allocated for reverb apbuf1");
+      };
+      apbuf2 = (float *)malloc(sizeof(float) * l_AP2);
+      if( apbuf2 == NULL){
+        DEBUG("No more RAM for reverb apbuf2!");
+      } else {
+        DEBUG("Memory allocated for reverb apbuf2");
+      };
+#endif 
+
+  	};
+		
+    inline void setTime( float value ){
+      rev_time = 0.92f * value + 0.02f ;
+      cf0_lim = (int)(rev_time * (l_CB0));
+      cf1_lim = (int)(rev_time * (l_CB1));
+      cf2_lim = (int)(rev_time * (l_CB2));
+      cf3_lim = (int)(rev_time * (l_CB3));
+      ap0_lim = (int)(rev_time * (l_AP0));
+      ap1_lim = (int)(rev_time * (l_AP1));
+      ap2_lim = (int)(rev_time * (l_AP2));
+#ifdef DEBUG_FX
+      DEBF("reverb time: %0.3f\n", value);
+#endif
+    };
+    
+    inline void setMix( float value ){
+      rev_level = value;
+#ifdef DEBUG_FX
+      DEBF("reverb level: %0.3f\n", value);
+#endif
+    };
+		
+	private:
+		float rev_time = 0.5f;
+		float rev_level = 0.5f;
+#ifdef STATIC_REV_BUFFER
+    float cfbuf0[l_CB0];
+    float cfbuf1[l_CB1];
+    float cfbuf2[l_CB2];
+    float cfbuf3[l_CB3];
+    float apbuf0[l_AP0];
+    float apbuf1[l_AP1];
+    float apbuf2[l_AP2];
+#else
+    float * cfbuf0 = NULL;
+    float * cfbuf1 = NULL;
+    float * cfbuf2 = NULL;
+    float * cfbuf3 = NULL;
+    float * apbuf0 = NULL;
+    float * apbuf1 = NULL;
+    float * apbuf2 = NULL;    
+#endif	
+		//define pointer limits = delay time
+		int cf0_lim, cf1_lim, cf2_lim, cf3_lim, ap0_lim, ap1_lim, ap2_lim;
+
+    
+    inline float Do_Comb0( float inSample ){
+      static int cf0_p = 0;
+      static float cf0_g = 0.805f;
+
+      float readback = cfbuf0[cf0_p];
+      float newV = readback * cf0_g + inSample;
+      cfbuf0[cf0_p] = newV;
+      cf0_p++;
+      if( cf0_p >= cf0_lim ){
+        cf0_p = 0;
+      }
+      return readback;
+    };
+
+    inline float Do_Comb1( float inSample ){
+      
+      static int cf1_p = 0;
+      static float cf1_g = 0.827f;
+
+      float readback = cfbuf1[cf1_p];
+      float newV = readback * cf1_g + inSample;
+      cfbuf1[cf1_p] = newV;
+      cf1_p++;
+      if( cf1_p >= cf1_lim ){
+        cf1_p = 0;
+      }
+      return readback;
+    };
+
+    inline float Do_Comb2( float inSample ){
+      static int cf2_p = 0;
+      static float cf2_g = 0.783f;
+
+      float readback = cfbuf2[cf2_p];
+      float newV = readback * cf2_g + inSample;
+      cfbuf2[cf2_p] = newV;
+      cf2_p++;
+      if( cf2_p >= cf2_lim ){
+        cf2_p = 0;
+      }
+      return readback;
+    };
+
+    inline float Do_Comb3( float inSample ){
+      static int cf3_p = 0;
+      static float cf3_g = 0.764f;
+
+      float readback = cfbuf3[cf3_p];
+      float newV = readback * cf3_g + inSample;
+      cfbuf3[cf3_p] = newV;
+      cf3_p++;
+      if( cf3_p >= cf3_lim ){
+        cf3_p = 0;
+      }
+      return readback;
+    };
+
+
+    inline float Do_Allpass0( float inSample ){
+      static int ap0_p = 0;
+      static float ap0_g = 0.7f;
+
+      float readback = apbuf0[ap0_p];
+      readback += (-ap0_g) * inSample;
+      float newV = readback * ap0_g + inSample;
+      apbuf0[ap0_p] = newV;
+      ap0_p++;
+      if( ap0_p >= ap0_lim ){
+        ap0_p = 0;
+      }
+      return readback;
+    };
+
+    inline float Do_Allpass1( float inSample ){
+      static int ap1_p = 0;
+      static float ap1_g = 0.7f;
+
+      float readback = apbuf1[ap1_p];
+      readback += (-ap1_g) * inSample;
+      float newV = readback * ap1_g + inSample;
+      apbuf1[ap1_p] = newV;
+      ap1_p++;
+      if( ap1_p >= ap1_lim ){
+        ap1_p = 0;
+      }
+      return readback;
+    };
+
+    inline float Do_Allpass2( float inSample ){
+      static int ap2_p = 0;
+      static float ap2_g = 0.7f;
+
+      float readback = apbuf2[ap2_p];
+      readback += (-ap2_g) * inSample;
+      float newV = readback * ap2_g + inSample;
+      apbuf2[ap2_p] = newV;
+      ap2_p++;
+      if( ap2_p >= ap2_lim ){
+        ap2_p = 0;
+      }
+      return readback;
+    };
+
+
+};

--- a/src/Nodes/WaveShaperNode.cpp
+++ b/src/Nodes/WaveShaperNode.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <Nodes/WaveShaperNode.h>
-
+#include "dspHelpers.h"
 
 WaveShaperNode::WaveShaperNode() {
 	; // be sure to call begin(fs)
@@ -30,8 +30,9 @@ void WaveShaperNode::begin(int sampleRate, int channelCount) {
 
 
 float WaveShaperNode::processSample(float sample, int channel) {
-	interpolator->process();
-	return fasttanh(sample * drive[kCurrent] * 30.f);
+	interpolator->process(); 
+//	extern inline float fast_shape(float x);
+	return fast_shape(sample * drive[kCurrent] * 30.f);
 }
 
 

--- a/src/Nodes/WaveShaperNode.h
+++ b/src/Nodes/WaveShaperNode.h
@@ -13,7 +13,6 @@
 #ifndef WAVESHAPER_H
 #define WAVESHAPER_H
 
-
 class WaveShaperNode : public AudioNode {
 
 public:

--- a/src/WaveSynth.h
+++ b/src/WaveSynth.h
@@ -14,7 +14,7 @@
 
 #ifndef WAVELIB
 #define WAVELIB
-
+	
 // ADSR
 class Envelope {
 	enum states {

--- a/src/YummyDSP.cpp
+++ b/src/YummyDSP.cpp
@@ -21,13 +21,14 @@ YummyDSP::~YummyDSP() {
 
 void YummyDSP::begin(int sampleRate) {
   	fs = sampleRate;
+	div_fs = 1.0f / (float)sampleRate;
 }
 
 void YummyDSP::addNode(AudioNode *node) {
 	nodelist.push_back(node);
 }
 
-float YummyDSP::process(float x, int channel) {
+float IRAM_ATTR YummyDSP::process(float x, int channel) {
 	float y = x;
 	// process all nodes
 	std::list<AudioNode *>::iterator it;

--- a/src/YummyDSP.h
+++ b/src/YummyDSP.h
@@ -5,21 +5,22 @@
  *  gary@ib-gru.de
 */
 
-
 #ifndef DSP_H
 #define DSP_H
 
+
 #include "Arduino.h"
+
 #include "Interpolator.h"
 #include "Nodes/AudioNode.h"
 #include "Nodes/FilterNode.h"
 #include "Nodes/MixerNode.h"
 #include "Nodes/WaveShaperNode.h"
 #include "Nodes/DelayNode.h"
+#include "Nodes/ReverbNode.h"
 
 #include "WaveSynth.h"
 #include <list>
-
 
 class YummyDSP {
 
@@ -27,20 +28,19 @@ class YummyDSP {
     YummyDSP();
 	YummyDSP(int fs);
     ~YummyDSP();
-
     void begin(int fs);
     int getSampleRate() { return fs; }
-	
+
 	void addNode(AudioNode *node);
 	
-	float process(float sample, int channel);
+	float IRAM_ATTR process(float sample, int channel);
+	
 
   protected:
-	std::list<AudioNode *> nodelist;
-	
     int fs; // sample rate
-
+	float div_fs; // one divided fs
+	std::list<AudioNode *> nodelist;
 };
 
-#endif
 
+#endif

--- a/src/dspHelpers.h
+++ b/src/dspHelpers.h
@@ -4,16 +4,188 @@
  *  Author: Gary Grutzek
  *  gary@ib-gru.de
 */
-
 #ifndef DSP_HELPERS_H
 #define DSP_HELPERS_H
 
+#include <Arduino.h>
 
-// Taken from https://github.com/ctag-fh-kiel/ctag-straempler/blob/master/components/audio/dsp_lib.c
-inline float fasttanh(float x){
-    float x2 = x*x;
-    return x * ( 27.f + x2 ) / ( 27.f + 9.f * x2 );
+// lookup tables
+#define TABLE_BIT  		      5UL				    // bits per index of lookup tables. 10 bit means 2^10 = 1024 samples. Values from 5 to 11 are OK. Choose the most appropriate.
+#define TABLE_SIZE            (1<<TABLE_BIT)        // samples used for lookup tables (it works pretty well down to 32 samples due to linear approximation, so listen and free some memory)
+#define TABLE_MASK  	      (TABLE_SIZE-1)        // strip MSB's and remain within our desired range of TABLE_SIZE
+#define DIV_TABLE_SIZE		  (1.0f/(float)TABLE_SIZE)
+#define CYCLE_INDEX(i)        (((int32_t)(i)) & TABLE_MASK ) // this way we can operate with periodic functions or waveforms with auto-phase-reset ("if's" are pretty CPU-costly)
+#define SHAPER_LOOKUP_MAX     5.0f                  // maximum X argument value for tanh(X) lookup table, tanh(X)~=1 if X>4 
+#define SHAPER_LOOKUP_COEF	  ((float)TABLE_SIZE / SHAPER_LOOKUP_MAX)
+#define TWOPI	6.283185307179586476925286766559f
+#define ONE_DIV_TWOPI	0.15915494309189533576888376337251f	
+
+static const float sin_tbl[TABLE_SIZE+1] = {
+	0.000000000f, 0.195090322f, 0.382683432f, 0.555570233f, 0.707106781f, 0.831469612f, 0.923879533f, 0.980785280f,
+	1.000000000f, 0.980785280f, 0.923879533f, 0.831469612f, 0.707106781f, 0.555570233f, 0.382683432f, 0.195090322f, 
+	0.000000000f, -0.195090322f, -0.382683432f, -0.555570233f, -0.707106781f, -0.831469612f, -0.923879533f, -0.980785280f, 
+	-1.000000000f, -0.980785280f, -0.923879533f, -0.831469612f, -0.707106781f, -0.555570233f, -0.382683432f, -0.195090322f, 0.000000000f };
+
+static const float shaper_tbl[TABLE_SIZE+1] {
+	0.000000000f, 0.154990730f, 0.302709729f, 0.437188785f, 0.554599722f, 0.653423588f, 0.734071520f, 0.798242755f, 
+	0.848283640f, 0.886695149f, 0.915824544f, 0.937712339f, 0.954045260f, 0.966170173f, 0.975136698f, 0.981748725f, 
+	0.986614298f, 0.990189189f, 0.992812795f, 0.994736652f, 0.996146531f, 0.997179283f, 0.997935538f, 0.998489189f, 
+	0.998894443f, 0.999191037f, 0.999408086f, 0.999566912f, 0.999683128f, 0.999768161f, 0.999830378f, 0.999875899f , 0.999909204f };
+
+
+inline float lookupTable(const float (&table)[TABLE_SIZE+1], float index ) { // lookup value in a table by float index, using linear interpolation
+  static float v1, v2, res;
+  static int32_t i;
+  static float f;
+  i = (int32_t)index;
+  f = (float)index - i;
+  v1 = (table)[i];
+  v2 = (table)[i+1];
+  res = (float)f * (float)(v2-v1) + v1;
+  return res;
 }
+
+inline float fclamp(float in, float min, float max){
+    return fmin(fmax(in, min), max);
+}
+
+inline float fast_shape(float x) {
+    float sign = 1.0f;
+    if (x < 0) {
+      x = -x;
+      sign = -1.0f;
+    }
+    if (x >= 4.95f) {
+      return sign; // tanh(x) ~= 1, when |x| > 4
+    }
+	return  sign * lookupTable(shaper_tbl, (x*SHAPER_LOOKUP_COEF)); // lookup table contains tanh(x), 0 <= x <= 5
+}
+
+inline float fast_sin(const float x) {
+	const float argument = ((x * ONE_DIV_TWOPI) * TABLE_SIZE);
+	const float res = lookupTable(sin_tbl, CYCLE_INDEX(argument)+((float)argument-(int32_t)argument));
+	return res;
+}
+
+inline float fast_cos(const float x) {
+	const float argument = ((x * ONE_DIV_TWOPI + 0.25f) * TABLE_SIZE);
+	const float res = lookupTable(sin_tbl, CYCLE_INDEX(argument)+((float)argument-(int32_t)argument));
+	return res;
+}
+
+inline void fast_sincos(const float x, float* sinRes, float* cosRes){
+	*sinRes = fast_sin(x);
+	*cosRes = fast_cos(x);
+}
+
+// reciprocal asm injection for xtensa LX6 FPU
+// https://blog.llandsmeer.com/tech/2021/04/08/esp32-s2-fpu.html
+inline float one_div(float a) {
+    float result;
+    asm volatile (
+        "wfr f1, %1"          "\n\t"
+        "recip0.s f0, f1"     "\n\t"
+        "const.s f2, 1"       "\n\t"
+        "msub.s f2, f1, f0"   "\n\t"
+        "maddn.s f0, f0, f2"  "\n\t"
+        "const.s f2, 1"       "\n\t"
+        "msub.s f2, f1, f0"   "\n\t"
+        "maddn.s f0, f0, f2"  "\n\t"
+        "rfr %0, f0"          "\n\t"
+        : "=r" (result)
+        : "r" (a)
+        : "f0","f1","f2"
+    );
+    return result;
+}
+
+// taken from here: https://www.esp32.com/viewtopic.php?t=10540#p43343
+// probably it's fixed already, so keep it here just in case
+inline float divsf(float a, float b) {
+    float result;
+    asm volatile (
+        "wfr f0, %1\n"
+        "wfr f1, %2\n"
+        "div0.s f3, f1 \n"
+        "nexp01.s f4, f1 \n"
+        "const.s f5, 1 \n"
+        "maddn.s f5, f4, f3 \n"
+        "mov.s f6, f3 \n"
+        "mov.s f7, f1 \n"
+        "nexp01.s f8, f0 \n"
+        "maddn.s f6, f5, f3 \n"
+        "const.s f5, 1 \n"
+        "const.s f2, 0 \n"
+        "neg.s f9, f8 \n"
+        "maddn.s f5,f4,f6 \n"
+        "maddn.s f2, f9, f3 \n" /* Original was "maddn.s f2, f0, f3 \n" */
+        "mkdadj.s f7, f0 \n"
+        "maddn.s f6,f5,f6 \n"
+        "maddn.s f9,f4,f2 \n"
+        "const.s f5, 1 \n"
+        "maddn.s f5,f4,f6 \n"
+        "maddn.s f2,f9,f6 \n"
+        "neg.s f9, f8 \n"
+        "maddn.s f6,f5,f6 \n"
+        "maddn.s f9,f4,f2 \n"
+        "addexpm.s f2, f7 \n"
+        "addexp.s f6, f7 \n"
+        "divn.s f2,f9,f6\n"
+        "rfr %0, f2\n"
+        :"=r"(result):"r"(a), "r"(b)
+    );
+    return result;
+}
+/*
+inline float dB2amp(float dB){
+  return expf(dB * 0.11512925464970228420089957273422f);
+  //return pow(10.0, (0.05*dB)); // naive, inefficient version
+}
+
+inline float amp2dB(float amp){
+  return 8.6858896380650365530225783783321f * logf(amp);
+  //return 20*log10(amp); // naive version
+}
+
+inline float linToLin(float in, float inMin, float inMax, float outMin, float outMax){
+  // map input to the range 0.0...1.0:
+  float tmp = (in-inMin) * one_div(inMax-inMin);
+
+  // map the tmp-value to the range outMin...outMax:
+  tmp *= (outMax-outMin);
+  tmp += outMin;
+
+  return tmp;
+}
+
+inline float linToExp(float in, float inMin, float inMax, float outMin, float outMax){
+  // map input to the range 0.0...1.0:
+  float tmp = (in-inMin) * one_div(inMax-inMin);
+
+  // map the tmp-value exponentially to the range outMin...outMax:
+  //tmp = outMin * exp( tmp*(log(outMax)-log(outMin)) );
+  return outMin * expf( tmp*(logf(outMax * one_div(outMin))) );
+}
+
+inline float expToLin(float in, float inMin, float inMax, float outMin, float outMax){
+  float tmp = logf(in * one_div(inMin)) * one_div( logf(inMax * one_div(inMin)));
+  return outMin + tmp * (outMax-outMin);
+}
+
+inline float knobMap(float in, float outMin, float outMax) {
+  return outMin + lookupTable(knob_tbl, (int)(in * TABLE_SIZE)) * (outMax - outMin);
+}
+
+inline float knob_fill(uint16_t i) { // f(x) = (exp(k*x)-1)/b, 0 <= x <= 1, 0 <= f(x) <= 1, x mapped to [0 .. TABLE_SIZE]
+  float x = (float)i * (float)DIV_TABLE_SIZE;
+  float res = ( expf((float)(x * 2.71f))-1.0f) * 0.071279495455219f;
+  return res;
+}
+
+inline float freqToPhaseInc(float freq, uint16_t sampleSize, uint16_t sampleRate) {
+  return freq * (float)sampleSize / (float)sampleRate;
+}
+*/
 
 #endif
 


### PR DESCRIPTION
-deprecated i2s constants removed, according recommendations;
+lookup tables (synth is untouched, though there may be also some extra memory to free);
+PSRAM for delay buffers (these buffers are in PSRAM when available), memset fixed; 
+ReverbNode (clean-up needed, numChannels not processed), cannot keep buffers in PSRAM due to slow QSPI, but we have now more RAM, as we moved delay to PSRAM; 
+PSRAM for delay buffers (these buffers are in PSRAM when available), memset fixed; 
-deprecated i2s constants removed, according recommendations;